### PR TITLE
Fix weird juxtaposition syntax in tests

### DIFF
--- a/test/exceptional.jl
+++ b/test/exceptional.jl
@@ -252,7 +252,7 @@ fun_table = Dict(SLEEFPirates.cos_fast => Base.cos, SLEEFPirates.cos => Base.cos
 end
 
 
-@testset "exceptional sin in $xsincos"for xsincos in (SLEEFPirates.sincos_fast, SLEEFPirates.sincos)
+@testset "exceptional sin in $xsincos" for xsincos in (SLEEFPirates.sincos_fast, SLEEFPirates.sincos)
     xa = T[NaN, -0.0, 0.0, Inf, -Inf]
     for x in xa
         q = xsincos(x)[1]
@@ -261,7 +261,7 @@ end
 end
 
 
-@testset "exceptional cos in $xsincos"for xsincos in (SLEEFPirates.sincos_fast, SLEEFPirates.sincos)
+@testset "exceptional cos in $xsincos" for xsincos in (SLEEFPirates.sincos_fast, SLEEFPirates.sincos)
     xa = T[NaN, -0.0, 0.0, Inf, -Inf]
     for x in xa
         q = xsincos(x)[2]


### PR DESCRIPTION
Found as part of testing for https://github.com/JuliaLang/julia/pull/46372 - JuliaSyntax.jl rejects this - it's more consistent about disallowing string juxtaposition with all keywords than the reference parser.