### PR TITLE
Fix Aqua deps_compat (Test) and piracy (treat VectorizationBase SIMD types as own)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,7 @@ VectorizationBase = "3d5dd08c-fd9d-11e8-17fa-ed2836048c2f"
 [compat]
 IfElse = "0.1"
 Static = "0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 1"
+Test = "1"
 VectorizationBase = "0.20.12, 0.21"
 julia = "1.5"
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,7 +12,17 @@ include("testsetup.jl")
 function runtests()
   @testset "SLEEFPirates" begin
     # @test isempty(detect_unbound_args(SLEEFPirates))
-    Aqua.test_all(SLEEFPirates)
+    Aqua.test_all(
+      SLEEFPirates;
+      piracies = (
+        treat_as_own = [
+          VectorizationBase.AbstractSIMD,
+          VectorizationBase.Vec,
+          VectorizationBase.MM,
+          VectorizationBase.VecUnroll,
+        ],
+      ),
+    )
     # include("exceptional.jl")
     include("accuracy.jl")
   end


### PR DESCRIPTION
## Summary

Two pre-existing Aqua hygiene failures on master CI that surface in JuliaSIMD/VectorizationBase.jl#127 / #128's downstream Interface checks:

1. **`Aqua.test_deps_compat`**: `Test` is in `[extras]` / `[targets]` but lacks a `[compat]` entry. Add `Test = "1"`.
2. **`Aqua.test_piracies`**: Flags the `^`, `sincospi`, `sinh`/`cosh`/`tanh`/`asinh`/`acosh`/`atanh`, `log1p`, `expm1` methods this package defines on `VectorizationBase.{AbstractSIMD, Vec, MM, VecUnroll}`. These are intentional — SLEEFPirates exists to extend `Base` math functions to those VectorizationBase types and is maintained alongside VectorizationBase. Use `Aqua.test_all(SLEEFPirates; piracies = (treat_as_own = [...]),)` to suppress the false positive.

`treat_as_own` uses `===` membership (not `<:`), so each individual type must be listed — `MM <: AbstractSIMD` doesn't transitively cover it.

## Test plan

- [x] `Aqua.test_deps_compat(SLEEFPirates)` passes locally.
- [x] `Aqua.test_piracies(SLEEFPirates; treat_as_own = [AbstractSIMD, Vec, MM, VecUnroll])` passes locally.
- [x] `Aqua.test_all(SLEEFPirates; ...)` 11/11 pass (was 9/11).
- [ ] CI: downstream Interface check in JuliaSIMD/VectorizationBase.jl#127/#128 should see Aqua green after this lands + tag.

## Out of scope

The `accuracy asinh/sin/cos/tan/...` Float32 numerical regressions are tracked separately — different failure mode, different fix area.

🤖 Generated with [Claude Code](https://claude.com/claude-code)