### PR TITLE
CI: switch macOS-latest to native aarch64 (drops Rosetta)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,18 @@ jobs:
           - ubuntu-latest
           - macOS-latest
           - windows-latest
-        arch:
-          - x64
+        include:
+          # Native arch per OS. `macOS-latest` is Apple silicon since the
+          # 2024 GitHub Actions image bump; forcing `arch: x64` there
+          # would run Julia under Rosetta emulation, which produces
+          # measurably different FP rounding (vexp2 / tanh_fast Float32
+          # accuracy tests exceed their ULP tolerance under Rosetta).
+          - os: ubuntu-latest
+            arch: x64
+          - os: macOS-latest
+            arch: aarch64
+          - os: windows-latest
+            arch: x64
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2


### PR DESCRIPTION
## Summary

`macOS-latest` is Apple silicon (ARM) since the 2024 GitHub Actions runner image refresh. The matrix introduced in #46 still set `arch: x64` for all OSes — on macOS-latest that means Julia downloads the x64 binary and runs it under **Rosetta emulation**, and Rosetta's FP rounding diverges enough from native x86 that two SLEEFPirates Float32 accuracy tests exceed their ULP tolerance:

| Function | Rosetta x64 | Native | Tolerance |
|---|---|---|---|
| `vexp2` | **2.37 ULP** at x=-3.499995 | ~1.0 ULP | 2 |
| `tanh_fast` | **5.24 ULP** at x=-5.288 | ~2.5 ULP | 4 |

Every `macOS-latest - x64` row of the matrix (Julia 1, lts, pre, nightly) failed identically because of this.

Fix: use a per-OS `include:` block to set `arch: aarch64` on macOS-latest and keep `arch: x64` on ubuntu/windows.

```yaml
include:
  - os: ubuntu-latest
    arch: x64
  - os: macOS-latest
    arch: aarch64
  - os: windows-latest
    arch: x64
```

The matrix shape is unchanged (4 versions × 3 OSes = 12 jobs); the difference is just the arch picked for macOS.

## Test plan

- [ ] CI on this branch: all macOS jobs that were failing on `accuracy vexp2` and `accuracy tanh_fast` should now pass.
- [ ] Julia `pre`/`nightly` macOS still soft-fails as expected for the `OncePerThread` / `DomainError` upstream issues, but doesn't block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)